### PR TITLE
Rename method to comply with Apple memory management rules

### DIFF
--- a/FontAwesomeKit/FontAwesomeKit.m
+++ b/FontAwesomeKit/FontAwesomeKit.m
@@ -85,7 +85,7 @@
 /**
  Gradient Helpers
  */
-+ (CGGradientRef)gradientWithColors:(NSArray *)colors locations:(NSArray *)locations
++ (CGGradientRef)newGradientWithColors:(NSArray *)colors locations:(NSArray *)locations
 {
 	CGColorSpaceRef colorSpace = CGColorSpaceCreateDeviceRGB();
 	CGGradientRef gradient;
@@ -135,7 +135,7 @@
 	UIGraphicsBeginImageContextWithOptions(size, NO, 0.0);
 	// ---------- begin context ----------
 	
-	CGGradientRef gradient = [self gradientWithColors:colors locations:locations];
+	CGGradientRef gradient = [self newGradientWithColors:colors locations:locations];
 	CGContextDrawLinearGradient(UIGraphicsGetCurrentContext(), gradient, startPoint, endPoint, kCGGradientDrawsBeforeStartLocation);
 	UIImage *gradientImage = UIGraphicsGetImageFromCurrentImageContext();
 	
@@ -158,7 +158,7 @@
 	UIGraphicsBeginImageContextWithOptions(size, NO, 0.0);
 	// ---------- begin context ----------
 	
-	CGGradientRef gradient = [self gradientWithColors:colors locations:locations];
+	CGGradientRef gradient = [self newGradientWithColors:colors locations:locations];
 	
 	CGContextDrawRadialGradient(UIGraphicsGetCurrentContext(), gradient, startCenter, startRadius, endCenter, endRadius, kCGGradientDrawsBeforeStartLocation);
 	CGGradientRelease(gradient);


### PR DESCRIPTION
I renamed gradientWithColors to newGradientWithColors to comply with the naming conventions for memory management from Apple:

https://developer.apple.com/library/mac/documentation/Cocoa/Conceptual/MemoryMgmt/Articles/mmRules.html#//apple_ref/doc/uid/20000994-BAJHFBGH

"You create an object using a method whose name begins with “alloc”, “new”, “copy”, or “mutableCopy” (for example, alloc, newObject, or mutableCopy)."

This gets rid of the the warning you get when you go to Product -> analyze.
