### PR TITLE
Use of -bundleForClass: for getting resources

### DIFF
--- a/FontAwesomeKit.podspec
+++ b/FontAwesomeKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "FontAwesomeKit"
-  s.version      = "2.1.8"
+  s.version      = "2.1.9"
   s.summary      = "Icon font library for iOS. Currently supports Font-Awesome, Foundation icons, Zocial, and ionicons"
   s.homepage     = "https://github.com/PrideChung/FontAwesomeKit"
   s.screenshots  = "http://i.minus.com/i3vNn0fTwcJeI.png", "http://i.minus.com/ivKqhOLJLVvmJ.png"

--- a/FontAwesomeKit/FAKFontAwesome.m
+++ b/FontAwesomeKit/FAKFontAwesome.m
@@ -9,7 +9,7 @@
 #ifndef DISABLE_FONTAWESOME_AUTO_REGISTRATION
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
-        [self registerIconFontWithURL:[[NSBundle mainBundle] URLForResource:@"FontAwesome" withExtension:@"otf"]];
+        [self registerIconFontWithURL:[[NSBundle bundleForClass:[FAKFontAwesome class]] URLForResource:@"FontAwesome" withExtension:@"otf"]];
     });
 #endif
     

--- a/FontAwesomeKit/FAKFoundationIcons.m
+++ b/FontAwesomeKit/FAKFoundationIcons.m
@@ -9,7 +9,7 @@
 #ifndef DISABLE_FOUNDATIONICONS_AUTO_REGISTRATION
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
-        [self registerIconFontWithURL: [[NSBundle mainBundle] URLForResource:@"foundation-icons" withExtension:@"ttf"]];
+        [self registerIconFontWithURL: [[NSBundle bundleForClass:[FAKFoundationIcons class]] URLForResource:@"foundation-icons" withExtension:@"ttf"]];
     });
 #endif
     

--- a/FontAwesomeKit/FAKIonIcons.m
+++ b/FontAwesomeKit/FAKIonIcons.m
@@ -7,7 +7,7 @@
 #ifndef DISABLE_IONICONS_AUTO_REGISTRATION
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
-        [self registerIconFontWithURL: [[NSBundle mainBundle] URLForResource:@"ionicons" withExtension:@"ttf"]];
+        [self registerIconFontWithURL: [[NSBundle bundleForClass:[FAKIonIcons class]] URLForResource:@"ionicons" withExtension:@"ttf"]];
     });
 #endif
     

--- a/FontAwesomeKit/FAKZocial.m
+++ b/FontAwesomeKit/FAKZocial.m
@@ -9,7 +9,7 @@
 #ifndef DISABLE_ZOCIAL_AUTO_REGISTRATION
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
-        [self registerIconFontWithURL: [[NSBundle mainBundle] URLForResource:@"zocial-regular-webfont" withExtension:@"ttf"]];
+        [self registerIconFontWithURL: [[NSBundle bundleForClass:[FAKZocial class]] URLForResource:@"zocial-regular-webfont" withExtension:@"ttf"]];
     });
 #endif
     

--- a/FontAwesomeKitTestHost/FontAwesomeKitTestHostTests/FAKMockIcon.m
+++ b/FontAwesomeKitTestHost/FontAwesomeKitTestHostTests/FAKMockIcon.m
@@ -7,7 +7,7 @@
 {
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
-        [self registerIconFontWithURL:[[NSBundle mainBundle] URLForResource:@"FontAwesome" withExtension:@"otf"]];
+        [self registerIconFontWithURL:[[NSBundle bundleForClass:[FAKMockIcon class]] URLForResource:@"FontAwesome" withExtension:@"otf"]];
     });
     
     UIFont *font = [UIFont fontWithName:@"FontAwesome" size:size];


### PR DESCRIPTION
Since cocoapods 0.36.1.beta, which introduces Frameworks and Swift, -bundleForClass must be used instead of mainBundle:
http://blog.cocoapods.org/Pod-Authors-Guide-to-CocoaPods-Frameworks/

I've made the changes to make the pod compatible for that