### PR TITLE
Fixes a crash that occurs during font registration

### DIFF
--- a/FontAwesomeKit/FAKIcon.m
+++ b/FontAwesomeKit/FAKIcon.m
@@ -18,7 +18,10 @@
     CFErrorRef error = NULL;
     CTFontManagerRegisterGraphicsFont(newFont, &error);
     CGFontRelease(newFont);
-    CFRelease(error);
+    
+    if (error) {
+        CFRelease(error);
+    }
 }
 
 + (NSDictionary *)allIcons


### PR DESCRIPTION
If the font registration succeeds the CFErrorRef reference is NULL. CFRelease() clearly states that the reference that is passed must not be NULL otherwise the program crashes. This PR fixes this crash.