### PR TITLE
Fix hang when called from appDidFinishLaunchingWithOptions

### DIFF
--- a/FontAwesomeKit/FAKIcon.m
+++ b/FontAwesomeKit/FAKIcon.m
@@ -13,6 +13,10 @@
 {
     NSAssert([[NSFileManager defaultManager] fileExistsAtPath:[url path]], @"Font file doesn't exist");
     CGDataProviderRef fontDataProvider = CGDataProviderCreateWithURL((__bridge CFURLRef)url);
+    
+    //Allows bypassing a semaphore loop when CGFontCreateWithDataProvider is called in appDidFinishLaunchingWithOptions
+    [UIFont familyNames];
+    
     CGFontRef newFont = CGFontCreateWithDataProvider(fontDataProvider);
     CGDataProviderRelease(fontDataProvider);
     CFErrorRef error = NULL;


### PR DESCRIPTION
Bug encountered :
Xcode 7.3
Real device, iOS 9.3.1
The app stuck at CGFontCreateWithDataProvider (see it only when pausing the process, display is stuck on launchscreen). The bug is reproducible on some devices, not all of them, but is always appearing on those devices.
Fix from http://stackoverflow.com/questions/24900979/cgfontcreatewithdataprovider-hangs-in-airplane-mode accepted answers, which got its fix from https://alpha.app.net/jaredsinclair/post/18555292

I don't know more about this bug, but this fix really fixed it for me